### PR TITLE
Bump px4_msgs version to 3.0.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>px4_msgs</name>
-  <version>2.0.1</version>
+  <version>3.0.0</version>
   <description>Package with the ROS-equivalent of PX4 uORB msgs</description>
   <maintainer email="nuno.marques@dronesolutions.io">Nuno Marques</maintainer>
   <author email="nuno.marques@dronesolutions.io">Nuno Marques</author>


### PR DESCRIPTION
A breaking change in messages due to px4-firmware rebase. This matches
the current px4-firmware 1.12+

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>