### PR TITLE
Fix PX4-msgs version to 6.0.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>px4_msgs</name>
-  <version>5.0.0</version>
+  <version>6.0.0</version>
   <description>Package with the ROS-equivalent of PX4 uORB msgs</description>
   <maintainer email="nuno.marques@dronesolutions.io">Nuno Marques</maintainer>
   <author email="nuno.marques@dronesolutions.io">Nuno Marques</author>


### PR DESCRIPTION
## Changelog:
- The px4-msgs pushed to artifactory is with old version name, `ros-humble-px4-msgs_5.0.0-50~git20231026.40b9a17`.
- This now conflicts with the old version, which is `
ros-humble-px4-msgs_5.0.0-48~git20230913.b90efad`
- Of course, this doesn't matter due to Yocto builds. However, for installing on the developer's computer, it is better to have the clarification of which package to install. After the newer version of `ros-humble-px4-msgs_6.0.0` is pushed to artifactory, we need to remove the incorrect one.