### PR TITLE
Add missing VehicleCommand service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,14 @@ find_package(rosidl_default_generators REQUIRED)
 set(MSGS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/msg")
 file(GLOB PX4_MSGS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${MSGS_DIR}/*.msg")
 
-file(GLOB ROS_MSG_DIR_LIST "${MSGS_DIR}/*.msg")
-
-set(ROS_MSG_DIR_LIST "${ROS_MSG_DIR_LIST}" CACHE INTERNAL "ROS_MSG_DIR_LIST")
+# get all srv files
+set(SRVS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/srv")
+file(GLOB PX4_SRVS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRVS_DIR}/*.srv")
 
 # Generate introspection typesupport for C and C++ and IDL files
-rosidl_generate_interfaces(${PROJECT_NAME} ${PX4_MSGS}
+rosidl_generate_interfaces(${PROJECT_NAME}
+	${PX4_MSGS}
+	${PX4_SRVS}
 	DEPENDENCIES builtin_interfaces
 	ADD_LINTER_TESTS
 )

--- a/srv/VehicleCommand.srv
+++ b/srv/VehicleCommand.srv
@@ -1,0 +1,3 @@
+VehicleCommand request
+---
+VehicleCommandAck reply


### PR DESCRIPTION
## Changelog:
- Added the vehicle_command service interface. It was left out during the 7.0.0 upgrade.