### PR TITLE
Add RedundancyStatus and RedundancyHwStatus messages

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -180,6 +180,8 @@ set(msg_files
 	RateCtrlStatus.msg
 	RcChannels.msg
 	RcParameterMap.msg
+	RedundancyHwStatus.msg
+	RedundancyStatus.msg
 	RegisterExtComponentReply.msg
 	RegisterExtComponentRequest.msg
 	RoverStatus.msg

--- a/msg/RedundancyHwStatus.msg
+++ b/msg/RedundancyHwStatus.msg
@@ -1,0 +1,9 @@
+uint64 timestamp			# time since system start (microseconds)
+
+bool wd_state
+uint8 switch_status
+uint8 driver_errors
+
+# Bit positions for driver error flags
+
+uint8 WD_TIMER_TIMEOUT = 0

--- a/msg/RedundancyStatus.msg
+++ b/msg/RedundancyStatus.msg
@@ -1,0 +1,25 @@
+# Encodes the redundancy state of the vehicle, as it appears to this FC
+
+uint64 timestamp # time since system start (microseconds)
+
+uint8 fc_number # Number of this FC, 1-4, matches MAV_COMP_ID
+uint8 fc_in_act_control # Which FC is in actuator control, 0 - unknown
+
+uint8 FC_UNKNOWN = 0
+uint8 FC1 = 1
+uint8 FC2 = 2
+uint8 FC3 = 3
+uint8 FC4 = 4
+
+uint32 error_flags # Bitmask of redundancy related errors
+
+# Bit positions for error_flags
+
+uint8 FC1_DISARMED_IN_FLIGHT = 0
+uint8 FC2_DISARMED_IN_FLIGHT = 1
+uint8 FC3_DISARMED_IN_FLIGHT = 2
+uint8 FC4_DISARMED_IN_FLIGHT = 3
+uint8 FC1_COMMS_ERR = 4
+uint8 FC2_COMMS_ERR = 5
+uint8 FC3_COMMS_ERR = 6
+uint8 FC4_COMMS_ERR = 7

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>px4_msgs</name>
-  <version>7.0.0</version>
+  <version>7.1.0</version>
   <description>Package with the ROS-equivalent of PX4 uORB msgs</description>
   <maintainer email="nuno.marques@dronesolutions.io">Nuno Marques</maintainer>
   <author email="nuno.marques@dronesolutions.io">Nuno Marques</author>


### PR DESCRIPTION
Add redundancy_status (and redundancy_hw_status) message, to be able to select whether listening/controlling primary or secondary FC via uxrce interface.